### PR TITLE
Don't always fetch the GnuPG key.

### DIFF
--- a/tools/bananian-update
+++ b/tools/bananian-update
@@ -56,7 +56,7 @@ cd $TMPDIR
 
 echo -e "---------------------------------------------------------------------------------"
 if gpg --list-keys 24BFF712 >/dev/null 2>&1;then 
-    echo -e "key already exists in GNUPG pubring... \n"
+    echo -e "key already exists in GNuPG pubring... \n"
 else
     echo -e "receiving public key... \n"
     gpg --recv-keys 24BFF712

--- a/tools/bananian-update
+++ b/tools/bananian-update
@@ -56,7 +56,7 @@ cd $TMPDIR
 
 echo -e "---------------------------------------------------------------------------------"
 if gpg --list-keys 24BFF712 >/dev/null 2>&1;then 
-    echo -e "key already exists in GNUPG pubring \n"
+    echo -e "key already exists in GNUPG pubring... \n"
 else
     echo -e "receiving public key... \n"
     gpg --recv-keys 24BFF712

--- a/tools/bananian-update
+++ b/tools/bananian-update
@@ -56,7 +56,7 @@ cd $TMPDIR
 
 echo -e "---------------------------------------------------------------------------------"
 if gpg --list-keys 24BFF712 >/dev/null 2>&1;then 
-    echo -e "key already exists in GNuPG pubring... \n"
+    echo -e "key already exists in GnuPG pubring... \n"
 else
     echo -e "receiving public key... \n"
     gpg --recv-keys 24BFF712

--- a/tools/bananian-update
+++ b/tools/bananian-update
@@ -55,8 +55,12 @@ TMPDIR=$(mktemp -d)
 cd $TMPDIR
 
 echo -e "---------------------------------------------------------------------------------"
-echo -e "receiving/updating public key... \n"
-gpg --recv-keys 24BFF712
+if gpg --list-keys 24BFF712 >/dev/null 2>&1;then 
+    echo -e "key already exists in GNUPG pubring \n"
+else
+    echo -e "receiving public key... \n"
+    gpg --recv-keys 24BFF712
+fi
 echo -e ""
 
 echo -e "---------------------------------------------------------------------------------"


### PR DESCRIPTION
Getting the gpg takes a lot of time, and seems not needed when it is already in our GnuPG keyring.
